### PR TITLE
movies exclusive to streaming platform

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/movie/serializers.py
+++ b/movie/serializers.py
@@ -51,6 +51,7 @@ class StreamPlatformSerializer(serializers.ModelSerializer):
         available_movies_data = validated_data.pop('available_movie')
         available_movies = []
         for available_movie_data in available_movies_data:
+
             try:
                 available_movie = AvailablePlatformsMovie.objects.get(title=available_movie_data['title'])
                 if available_movie in available_movies:
@@ -66,6 +67,7 @@ class StreamPlatformSerializer(serializers.ModelSerializer):
         available_movies_data = validated_data.pop('available_movie')
         available_movies = []
         for available_movie_data in available_movies_data:
+
             try:
                 available_movie = AvailablePlatformsMovie.objects.get(title=available_movie_data['title'])
                 if available_movie in available_movies:


### PR DESCRIPTION
The streaming platform will have its own movies (exclusive movies), when adding a movie to your movie list it is required to specify to which streaming platform it belongs to, based on the specified streaming platform, it will check the movie title if its in the specific streaming platform available movies.
![Screenshot 2023-04-19 at 5 06 36 PM](https://user-images.githubusercontent.com/128303344/233032582-cdbfa912-5924-4718-9125-0ff2399c0518.png)
![Screenshot 2023-04-20 at 1 03 01 PM](https://user-images.githubusercontent.com/131318450/233269496-ea4f622f-fe74-4f2a-9a3e-64c5ac865bd2.png)
based on the second image, "Murder Mystery 2" is not in the available_movies therefore it raise a validation error, this was done by modifying the def create() and def update() of the movie serializer.
A validation error is raised when duplicates of stream_platform and available_movies is created.